### PR TITLE
Added send queue for Telldus Core, created README

### DIFF
--- a/addons/binding/org.openhab.binding.tellstick/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.tellstick/ESH-INF/binding/binding.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
     <name>Tellstick Binding</name>
-    <description>This is the binding for Telldus Tellstick Basic and Duo and .Net. www.telldus.com</description>
-    <author>jarlebh</author> 
+    <description>This is the binding for Telldus Tellstick Basic, Duo, .Net and Z-Net Lite. www.telldus.com</description>
+    <author>Jarle Hjortland</author> 
 
 </binding:binding>

--- a/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/bridge.xml
+++ b/addons/binding/org.openhab.binding.tellstick/ESH-INF/thing/bridge.xml
@@ -5,9 +5,8 @@
     xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<bridge-type id="telldus-core">
-		<label>Telldus Center gateway</label>
-		<description>This bridge represents the telldus center.
-		</description>
+		<label>Telldus Core gateway</label>
+		<description>This bridge represents the telldus center on a local computer.</description>
 
 		<config-description>
 			<parameter name="libraryPath" type="text" required="false">
@@ -26,8 +25,7 @@
 	</bridge-type>
 	<bridge-type id="telldus-live">
         <label>Telldus Live gateway</label>
-        <description>This bridge represents the telldus live service.
-        </description>
+        <description>This bridge represents the telldus live cloud service.</description>
 
         <config-description>
             <parameter name="privateKey" type="text" required="true">

--- a/addons/binding/org.openhab.binding.tellstick/README.md
+++ b/addons/binding/org.openhab.binding.tellstick/README.md
@@ -1,0 +1,52 @@
+#Tellstick Binding
+
+This is an OpenHAB binding for Tellstick devices produced by Telldus, a Swedish company based in Lund.
+
+The original Tellstick focused on controlling 433 MHz devices like switches, dimmers and reading sensors from different brands. <br>
+Many of the supported devices are cheaper and "low-end" and support have been made by reverse engineer the transmission protocols. <br>
+All of these 433 MHz devices is one-way, so some versions of the Tellstick monitoring the air to keep the state of all devices. 
+  
+The latest versions have also implemented Z-Wave as transmission protocol which open up for more robust transmission due two-ways communication. 
+ 
+## Supported Things
+
+This binding implements two different API:  
+**1)** *Telldus Core* which is a local only interface supported by USB based device. <br>
+**2)** *Telldus Live* which is a REST based cloud service maintained by Telldus. <br>
+3) (According to [Telldus](http://developer.telldus.com/blog/2016/01/21/local-api-for-tellstick-znet-lite-beta) are they working with a local REST based API for the new Z-Wave devices. This is currently **NOT** supported by this binding.)
+
+Depending on your Tellstick model different API methods is available: 
+
+<table>
+<tr><td><b>Model</b></td> <td><b>Telldus Core</b></td> <td><b>Telldus Live</b></td> <td><b>Verified working with openHAB</b></td></tr>
+<tr><td>Tellstick Basic</td><td>X</td><td>X</td></tr>
+<tr><td>Tellstick Duo</td><td>X</td><td>X</td><td>X</td></tr>
+<tr><td>Tellstick Net</td><td></td><td>X</td></tr>
+<tr><td>Tellstick ZNet Lite</td><td></td><td>X</td></tr>
+<tr><td>Tellstick ZNet Pro</td><td></td><td>X</td></tr>
+</table>
+
+
+This binding supports the following thing types:
+
+TBD
+
+## Binding Configuration
+
+No binding configuration required.
+
+## Discovery
+
+TBD
+
+## Thing Configuration
+
+TBD
+
+## Channels
+
+TBD
+
+## Full Example
+
+TBD

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/TelldusDeviceController.java
@@ -50,4 +50,11 @@ public interface TelldusDeviceController {
      */
     BigDecimal calcDimValue(Device device);
 
+    /**
+     *
+     * Clean up the device controller before shutdown.
+     *
+     */
+    void dispose();
+
 }

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/core/TelldusCoreBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/core/TelldusCoreBridgeHandler.java
@@ -77,6 +77,7 @@ public class TelldusCoreBridgeHandler extends BaseBridgeHandler
     @Override
     public void dispose() {
         logger.debug("Telldus Core Handler disposed.");
+        deviceController.dispose();
         eventHandler.remove();
         clearDeviceList();
         initialized = false;

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/core/TelldusCoreDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/core/TelldusCoreDeviceController.java
@@ -38,6 +38,7 @@ import org.tellstick.device.iface.SwitchableDevice;
  * library.
  *
  * @author Jarle Hjortland
+ * @author Elias Gabrielsson
  *
  */
 public class TelldusCoreDeviceController implements DeviceChangeListener, SensorListener, TelldusDeviceController {
@@ -55,6 +56,11 @@ public class TelldusCoreDeviceController implements DeviceChangeListener, Sensor
         messageQue = Collections.synchronizedSortedMap(new TreeMap<Device, TelldusCoreSendEvent>());
         telldusCoreWorker = new TelldusCoreWorker(messageQue);
         workerThread = new Thread(telldusCoreWorker);
+    }
+
+    @Override
+    public void dispose() {
+        workerThread.interrupt();
     }
 
     @Override
@@ -247,7 +253,7 @@ public class TelldusCoreDeviceController implements DeviceChangeListener, Sensor
 
         @Override
         public void run() {
-            while (true) {
+            while (!Thread.currentThread().isInterrupted()) {
                 try {
                     TelldusCoreSendEvent sendEvent;
                     // Get event to send

--- a/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/live/TelldusLiveDeviceController.java
+++ b/addons/binding/org.openhab.binding.tellstick/src/main/java/org/openhab/binding/tellstick/handler/live/TelldusLiveDeviceController.java
@@ -76,6 +76,11 @@ public class TelldusLiveDeviceController implements DeviceChangeListener, Sensor
     public TelldusLiveDeviceController() {
     }
 
+    @Override
+    public void dispose() {
+        client.closeAsynchronously();
+    }
+
     void connectHttpClient(String publicKey, String privateKey, String token, String tokenSecret) {
         ConsumerKey consumer = new ConsumerKey(publicKey, privateKey);
         RequestToken user = new RequestToken(token, tokenSecret);


### PR DESCRIPTION
- Made queue which only send the last relevant event to the radio interface.
- Started on a README, needs more work to be complete. Especially configuration examples.
- Wrote out Jarle Hjortland in ESH-INF so it will be displayed more nicely in the paper-ui.
- Changed "Tellstick Center" to "Tellstick Core" in bridge types.
  I found it messy with center because "Tellstick Live" API uses the "Tellstick Center" desktop app for configuration which confused me.

Signed-off-by: Elias Gabrielsson elias@rehash.se (github: EliasGabrielsson)
