### PR TITLE
Casting of ClimateSensor update to StringType

### DIFF
--- a/addons/binding/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/handler/VerisureObjectHandler.java
+++ b/addons/binding/org.openhab.binding.verisure/src/main/java/org/openhab/binding/verisure/handler/VerisureObjectHandler.java
@@ -152,11 +152,11 @@ public class VerisureObjectHandler extends BaseThingHandler implements DeviceSta
         String val = obj.getTemperature().substring(0, obj.getTemperature().length() - 6).replace(",", ".");
 
         DecimalType number = new DecimalType(val);
-        updateState(cuid, number);
+        updateState(cuid, new StringType(number.toString()));
         if (obj.getHumidity() != null && obj.getHumidity().length() > 1) {
             val = obj.getHumidity().substring(0, obj.getHumidity().indexOf("%")).replace(",", ".");
             DecimalType hnumber = new DecimalType(val);
-            updateState(huid, hnumber);
+            updateState(huid, new StringType(hnumber.toString()));
         }
         StringType lastUpdate = new StringType(obj.getTimestamp());
         updateState(luid, lastUpdate);


### PR DESCRIPTION
An issue with DecimalType for humidity and temperature sensors causes the updateState not to register changes.
Casting to StringType before updating fixes this.

Signed-off-by: Robin Sving <robin.sving@email.com> (github: robinsving)